### PR TITLE
feat: serializes builds and cancels redundant PR checks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,15 @@ on:
       - develop
       - master
 
+concurrency:
+  # Support push/pr as event types with different behaviors each:
+  # 1. push: queue up builds by branch
+  # 2. pr: only allow one run per PR
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}
+  # If there is already a workflow running for the same pull request, cancel it
+  # For non-PR triggers queue up builds
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* when a PR check is in flight and a new PR revision is pushed the existing check is now canceled
* serializes runs per branch to facilitate identifying when a build broke and to support atomic releases

# Testing

Not tested