### PR TITLE
feat: automatically moves issues to board

### DIFF
--- a/.github/workflows/intake.yml
+++ b/.github/workflows/intake.yml
@@ -1,0 +1,43 @@
+# This workflow moves issues to the Kotlin board
+# when they receive the "accepted" label
+# When WalletConnect Org members create issues they
+# are automatically "accepted".
+# Else they need to manually receive that label during intake.
+name: intake
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  add-to-project:
+    name: Add issue to board
+    if: github.event.action == 'labeled' && github.event.label.name == 'accepted'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/WalletConnect/projects/4
+          github-token: ${{ secrets.ASSIGN_TO_PROJECT_GITHUB_TOKEN }}
+          labeled: accepted
+          label-operator: OR
+  auto-promote:
+    name: auto-promote
+    if: github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if organization member
+        id: is_organization_member
+        if: github.event.action == 'opened'
+        uses: JamesSingleton/is-organization-member@1.0.0
+        with:
+          organization: WalletConnect
+          username: ${{ github.event_name != 'pull_request' && github.event.issue.user.login || github.event.sender.login }}
+          token: ${{ secrets.ASSIGN_TO_PROJECT_GITHUB_TOKEN }}
+      - name: Label issues
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "accepted"
+          repo-token: ${{ secrets.ASSIGN_TO_PROJECT_GITHUB_TOKEN }}


### PR DESCRIPTION
If a team member creates an issue it goes straight to the board, else it needs to be labeled as "accepted".

# Testing
Tested in the monorepo and just copy/pasta here.