### PR TITLE
✨ Make network client timeout customizable

### DIFF
--- a/androidCore/sdk/src/main/kotlin/com/walletconnect/android/CoreClient.kt
+++ b/androidCore/sdk/src/main/kotlin/com/walletconnect/android/CoreClient.kt
@@ -7,6 +7,7 @@ import com.walletconnect.android.internal.common.di.coreCryptoModule
 import com.walletconnect.android.internal.common.di.coreJsonRpcModule
 import com.walletconnect.android.internal.common.di.corePairingModule
 import com.walletconnect.android.internal.common.model.AppMetaData
+import com.walletconnect.android.internal.common.model.NetworkClientTimeout
 import com.walletconnect.android.internal.common.model.ProjectId
 import com.walletconnect.android.internal.common.model.Redirect
 import com.walletconnect.android.internal.common.wcKoinApp
@@ -33,6 +34,7 @@ object CoreClient {
         connectionType: ConnectionType,
         application: Application,
         relay: RelayConnectionInterface? = null,
+        networkClientTimeout: NetworkClientTimeout? = null,
         onError: (Core.Model.Error) -> Unit
     ) {
         plantTimber()
@@ -51,7 +53,7 @@ object CoreClient {
         }
 
         if (relay == null) {
-            RelayClient.initialize(relayServerUrl, connectionType) { error -> onError(Core.Model.Error(error)) }
+            RelayClient.initialize(relayServerUrl, connectionType, networkClientTimeout) { error -> onError(Core.Model.Error(error)) }
         }
         PairingProtocol.initialize()
         PairingController.initialize()

--- a/androidCore/sdk/src/main/kotlin/com/walletconnect/android/internal/common/di/CoreNetworkModule.kt
+++ b/androidCore/sdk/src/main/kotlin/com/walletconnect/android/internal/common/di/CoreNetworkModule.kt
@@ -10,6 +10,7 @@ import com.tinder.scarlet.retry.LinearBackoffStrategy
 import com.tinder.scarlet.websocket.okhttp.newWebSocketFactory
 import com.walletconnect.android.internal.common.connection.ConnectivityState
 import com.walletconnect.android.internal.common.connection.ManualConnectionLifecycle
+import com.walletconnect.android.internal.common.model.NetworkClientTimeout
 import com.walletconnect.android.relay.ConnectionType
 import com.walletconnect.foundation.network.data.ConnectionController
 import com.walletconnect.foundation.network.data.adapter.FlowStreamAdapter
@@ -21,9 +22,10 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.util.concurrent.TimeUnit
 
-fun coreAndroidNetworkModule(serverUrl: String, jwt: String, connectionType: ConnectionType, sdkVersion: String) = module {
+fun coreAndroidNetworkModule(serverUrl: String, jwt: String, connectionType: ConnectionType, sdkVersion: String, timeout: NetworkClientTimeout? = null) = module {
     val DEFAULT_BACKOFF_SECONDS = 5L
-    val TIMEOUT_TIME = 5000L
+
+    val networkClientTimeout = timeout ?: NetworkClientTimeout.getDefaultTimeout()
 
     single(named(AndroidCommonDITags.INTERCEPTOR)) {
         Interceptor { chain ->
@@ -38,10 +40,10 @@ fun coreAndroidNetworkModule(serverUrl: String, jwt: String, connectionType: Con
     single(named(AndroidCommonDITags.OK_HTTP)) {
         OkHttpClient.Builder()
             .addInterceptor(get<Interceptor>(named(AndroidCommonDITags.INTERCEPTOR)))
-            .writeTimeout(TIMEOUT_TIME, TimeUnit.MILLISECONDS)
-            .readTimeout(TIMEOUT_TIME, TimeUnit.MILLISECONDS)
-            .callTimeout(TIMEOUT_TIME, TimeUnit.MILLISECONDS)
-            .connectTimeout(TIMEOUT_TIME, TimeUnit.MILLISECONDS)
+            .writeTimeout(networkClientTimeout.timeout, networkClientTimeout.timeUnit)
+            .readTimeout(networkClientTimeout.timeout, networkClientTimeout.timeUnit)
+            .callTimeout(networkClientTimeout.timeout, networkClientTimeout.timeUnit)
+            .connectTimeout(networkClientTimeout.timeout, networkClientTimeout.timeUnit)
             .build()
     }
 

--- a/androidCore/sdk/src/main/kotlin/com/walletconnect/android/internal/common/model/NetworkClientTimeout.kt
+++ b/androidCore/sdk/src/main/kotlin/com/walletconnect/android/internal/common/model/NetworkClientTimeout.kt
@@ -1,0 +1,16 @@
+package com.walletconnect.android.internal.common.model
+
+import java.util.concurrent.TimeUnit
+
+data class NetworkClientTimeout(
+    val timeout: Long,
+    val timeUnit: TimeUnit
+) {
+
+    companion object {
+        fun getDefaultTimeout() = NetworkClientTimeout(
+            timeout = 5000L,
+            timeUnit = TimeUnit.MILLISECONDS
+        )
+    }
+}

--- a/androidCore/sdk/src/main/kotlin/com/walletconnect/android/relay/RelayClient.kt
+++ b/androidCore/sdk/src/main/kotlin/com/walletconnect/android/relay/RelayClient.kt
@@ -7,7 +7,7 @@ import com.walletconnect.android.internal.common.connection.ConnectivityState
 import com.walletconnect.android.internal.common.di.AndroidCommonDITags
 import com.walletconnect.android.internal.common.di.coreAndroidNetworkModule
 import com.walletconnect.android.internal.common.exception.WRONG_CONNECTION_TYPE
-import com.walletconnect.android.internal.common.exception.WalletConnectException
+import com.walletconnect.android.internal.common.model.NetworkClientTimeout
 import com.walletconnect.android.internal.common.scope
 import com.walletconnect.android.internal.common.wcKoinApp
 import com.walletconnect.android.utils.*
@@ -25,7 +25,7 @@ object RelayClient : BaseRelayClient(), RelayConnectionInterface {
     private val isWSSConnectionOpened: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     @JvmSynthetic
-    internal fun initialize(relayServerUrl: String, connectionType: ConnectionType, onError: (Throwable) -> Unit) {
+    internal fun initialize(relayServerUrl: String, connectionType: ConnectionType, networkClientTimeout: NetworkClientTimeout? = null, onError: (Throwable) -> Unit) {
         require(relayServerUrl.isValidRelayServerUrl()) { "Check the schema and projectId parameter of the Server Url" }
 
         logger = wcKoinApp.koin.get(named(AndroidCommonDITags.LOGGER))
@@ -33,7 +33,7 @@ object RelayClient : BaseRelayClient(), RelayConnectionInterface {
         val jwt = jwtRepository.generateJWT(relayServerUrl.strippedUrl())
         val serverUrl = relayServerUrl.addUserAgent(BuildConfig.SDK_VERSION)
 
-        wcKoinApp.modules(coreAndroidNetworkModule(serverUrl, jwt, connectionType.toCommonConnectionType(), BuildConfig.SDK_VERSION))
+        wcKoinApp.modules(coreAndroidNetworkModule(serverUrl, jwt, connectionType.toCommonConnectionType(), BuildConfig.SDK_VERSION, networkClientTimeout))
         relayService = wcKoinApp.koin.get(named(AndroidCommonDITags.RELAY_SERVICE))
 
         collectConnectionErrors(onError)


### PR DESCRIPTION
Purpose of this PR is to make network client's timeout customizable. 

In our wallet, we support both WC V1 and WC V2. We use 10 seconds as timeout for V1. However for V2 it is 5 seconds as default and it makes things on our end a little bit inconsistent. 

Thanks in advance!