### PR TITLE
Updates to CacaoSignerInterface file

### DIFF
--- a/androidCore/sdk/src/main/kotlin/com/walletconnect/android/utils/cacao/CacaoSignerInterface.kt
+++ b/androidCore/sdk/src/main/kotlin/com/walletconnect/android/utils/cacao/CacaoSignerInterface.kt
@@ -1,5 +1,5 @@
 @file:JvmName("CacaoSignerUtil")
-@file:Suppress("PackageDirectoryMismatch", "UNCHECKED_CAST")
+@file:Suppress("PackageDirectoryMismatch", "UNCHECKED_CAST") // Added to dismiss confusion. Cast to `T` always succeeds as Cacao.Signature implements ISignature.
 
 package com.walletconnect.android.utils.cacao
 
@@ -14,7 +14,7 @@ import kotlin.reflect.full.createType
 
 interface CacaoSignerInterface<CoreSignature : SignatureInterface>
 
-@Suppress("UNCHECKED_CAST", "unused") // Added to dismiss confusion. Cast to `T` always succeeds as Cacao.Signature implements ISignature.
+@Suppress("unused")
 inline fun <CoreSignature : SignatureInterface, reified SDKSignature : CoreSignature> CacaoSignerInterface<CoreSignature>.sign(
     message: String,
     privateKey: ByteArray,
@@ -37,6 +37,10 @@ fun <T : SignatureInterface> sign(clazz: Class<T>, message: String, privateKey: 
         else -> throw Throwable("SignatureType not recognized")
     }
 
+// This function is used to check if the constructor of the SignatureInterface impl has
+// * exactly 3 parameters
+// * the parameters in the correct order
+// * the parameters are of the exact names that match the interface
 fun <T : SignatureInterface> KFunction<T>.hasCorrectOrderedParametersInConstructor(): Boolean =
     parameters.takeIf { it.size == 3 }?.run {
         val stringType = String::class.createType(nullable = false).javaClass

--- a/androidCore/sdk/src/test/java/CacaoTestJvmTest.java
+++ b/androidCore/sdk/src/test/java/CacaoTestJvmTest.java
@@ -1,10 +1,10 @@
-import com.walletconnect.android.cacao.CacaoSignerInterfaceKt;
 import com.walletconnect.android.cacao.signature.SignatureType;
 import com.walletconnect.android.internal.common.cacao.Cacao;
 import com.walletconnect.android.internal.common.cacao.CacaoKt;
 import com.walletconnect.android.internal.common.cacao.CacaoType;
 import com.walletconnect.android.internal.common.cacao.CacaoVerifier;
 import com.walletconnect.android.internal.common.model.ProjectId;
+import com.walletconnect.android.utils.cacao.CacaoSignerUtil;
 import com.walletconnect.util.UtilFunctionsKt;
 
 import org.junit.jupiter.api.Assertions;
@@ -40,7 +40,7 @@ class CacaoTestJvmTest {
 
         String chainName = "Ethereum";
         String message = CacaoKt.toCAIP122Message(payload, chainName);
-        SignatureTest signature = (SignatureTest) CacaoSignerInterfaceKt.signCacao(SignatureTest.class, message, privateKey, SignatureType.EIP191);
+        SignatureTest signature = CacaoSignerUtil.sign(SignatureTest.class, message, privateKey, SignatureType.EIP191);
         Cacao.Signature cacaoSig = new Cacao.Signature(signature.getT(), signature.getS(), signature.getM());
         Cacao cacao = new Cacao(CacaoType.EIP4361.toHeader(), payload, cacaoSig);
 


### PR DESCRIPTION
* Moved CacaoSignatureInterface outside of internal package
* Changed signCacao to just sign to match existing sign function.
* Updated new sign function to match the logic of the original sign function
* Added a comment about what hasCorrectOrderedParametersInConstructor does