### PR TITLE
wip: how to listen to sync events in other protocols

### DIFF
--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/client/ChatProtocol.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/client/ChatProtocol.kt
@@ -30,6 +30,7 @@ internal class ChatProtocol : ChatInterface {
                 modules(
                     jsonRpcModule(),
                     storageModule(),
+                    syncInChatModule(),
                     engineModule(),
                     commonModule()
                 )

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/di/EngineModule.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/di/EngineModule.kt
@@ -4,6 +4,7 @@ package com.walletconnect.chat.di
 
 import com.walletconnect.android.internal.common.di.AndroidCommonDITags
 import com.walletconnect.chat.engine.domain.ChatEngine
+import com.walletconnect.chat.engine.use_case.calls.AcceptInviteUseCase
 import com.walletconnect.chat.json_rpc.GetPendingJsonRpcHistoryEntryByIdUseCase
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -11,6 +12,8 @@ import org.koin.dsl.module
 @JvmSynthetic
 internal fun engineModule() = module {
     single { GetPendingJsonRpcHistoryEntryByIdUseCase(get(), get()) }
+
+    single { AcceptInviteUseCase(get(), get(), get(), get(), get(), get(), get(), get()) }
 
     single {
         ChatEngine(
@@ -28,7 +31,10 @@ internal fun engineModule() = module {
             invitesRepository = get(),
             messageRepository = get(),
             accountsRepository = get(),
-            logger = get(named(AndroidCommonDITags.LOGGER))
+            logger = get(named(AndroidCommonDITags.LOGGER)),
+            syncInterface = get(),
+            onSyncUpdateUseCase = get(),
+            acceptInviteUseCase = get()
         )
     }
 }

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/di/SyncInChatModule.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/di/SyncInChatModule.kt
@@ -1,0 +1,17 @@
+@file:JvmSynthetic
+
+package com.walletconnect.chat.di
+
+import com.walletconnect.chat.engine.sync.updates.OnChatInviteUpdateUseCase
+import com.walletconnect.chat.engine.sync.updates.OnInviteKeysUpdateUseCase
+import com.walletconnect.chat.engine.sync.updates.OnSyncUpdateUseCase
+import com.walletconnect.chat.engine.sync.updates.OnThreadsUpdateUseCase
+import org.koin.dsl.module
+
+@JvmSynthetic
+internal fun syncInChatModule() = module {
+    single { OnChatInviteUpdateUseCase(get()) }
+    single { OnInviteKeysUpdateUseCase() }
+    single { OnThreadsUpdateUseCase() }
+    single { OnSyncUpdateUseCase(get(), get(), get()) }
+}

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnChatInviteUpdateUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnChatInviteUpdateUseCase.kt
@@ -1,0 +1,19 @@
+package com.walletconnect.chat.engine.sync.updates
+
+import com.walletconnect.android.sync.common.model.Events
+import com.walletconnect.android.sync.common.model.SyncUpdate
+import com.walletconnect.chat.engine.use_case.calls.AcceptInviteUseCase
+
+internal class OnChatInviteUpdateUseCase(
+    private val acceptInviteUseCase: AcceptInviteUseCase,
+) {
+    operator fun invoke(event: Events.OnSyncUpdate) {
+        // When the chat invite update come it means someone replied to an invite from other client
+        when (val update = event.update) {
+            is SyncUpdate.SyncSet -> {
+                acceptInviteUseCase.accept(update.value.toLong(), {}, {}) //todo
+            }
+            is SyncUpdate.SyncDelete -> TODO()
+        }
+    }
+}

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnInviteKeysUpdateUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnInviteKeysUpdateUseCase.kt
@@ -1,0 +1,11 @@
+package com.walletconnect.chat.engine.sync.updates
+
+import com.walletconnect.android.sync.common.model.Events
+
+internal class OnInviteKeysUpdateUseCase(
+
+) {
+    operator fun invoke(event: Events.OnSyncUpdate) {
+
+    }
+}

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnSyncUpdateUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnSyncUpdateUseCase.kt
@@ -1,0 +1,25 @@
+package com.walletconnect.chat.engine.sync.updates
+
+import com.walletconnect.android.sync.common.model.Events
+
+
+internal class OnSyncUpdateUseCase(
+    private val onChatInviteUpdateUseCase: OnChatInviteUpdateUseCase,
+    private val onThreadsUpdateUseCase: OnThreadsUpdateUseCase,
+    private val onInviteKeysUpdateUseCase: OnInviteKeysUpdateUseCase,
+) {
+    operator fun invoke(event: Events.OnSyncUpdate) {
+        when (event.store.value) {
+            CHAT_SENT_INVITES -> onChatInviteUpdateUseCase(event)
+            CHAT_THREADS -> onThreadsUpdateUseCase(event)
+            CHAT_INVITE_KEYS -> onInviteKeysUpdateUseCase(event)
+        }
+    }
+
+    companion object {
+        const val CHAT_SENT_INVITES = "chatSentInvites"
+        const val CHAT_THREADS = "chatThreads" // imo needs to sync threads sym keys not threads itself
+        const val CHAT_INVITE_KEYS = "chatInviteKeys" // imo needs to sync threads sym keys not threads itself
+    }
+}
+

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnThreadsUpdateUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/sync/updates/OnThreadsUpdateUseCase.kt
@@ -1,0 +1,9 @@
+package com.walletconnect.chat.engine.sync.updates
+
+import com.walletconnect.android.sync.common.model.Events
+
+internal class OnThreadsUpdateUseCase() {
+    operator fun invoke(event: Events.OnSyncUpdate) {
+
+    }
+}

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/calls/AcceptInviteUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/calls/AcceptInviteUseCase.kt
@@ -1,0 +1,95 @@
+package com.walletconnect.chat.engine.use_case.calls
+
+import com.walletconnect.android.internal.common.JsonRpcResponse
+import com.walletconnect.android.internal.common.crypto.kmr.KeyManagementRepository
+import com.walletconnect.android.internal.common.jwt.did.EncodeDidJwtPayloadUseCase
+import com.walletconnect.android.internal.common.jwt.did.encodeDidJwt
+import com.walletconnect.android.internal.common.model.AccountId
+import com.walletconnect.android.internal.common.model.IrnParams
+import com.walletconnect.android.internal.common.model.Tags
+import com.walletconnect.android.internal.common.model.params.CoreChatParams
+import com.walletconnect.android.internal.common.model.type.JsonRpcInteractorInterface
+import com.walletconnect.android.internal.common.scope
+import com.walletconnect.android.internal.utils.MONTH_IN_SECONDS
+import com.walletconnect.android.internal.utils.SELF_INVITE_PUBLIC_KEY_CONTEXT
+import com.walletconnect.android.keyserver.domain.IdentitiesInteractor
+import com.walletconnect.chat.common.exceptions.MissingInviteRequestException
+import com.walletconnect.chat.common.model.InviteStatus
+import com.walletconnect.chat.json_rpc.GetPendingJsonRpcHistoryEntryByIdUseCase
+import com.walletconnect.chat.jwt.use_case.EncodeInviteApprovalDidJwtPayloadUseCase
+import com.walletconnect.chat.storage.InvitesStorageRepository
+import com.walletconnect.chat.storage.ThreadsStorageRepository
+import com.walletconnect.foundation.common.model.Ttl
+import com.walletconnect.foundation.util.Logger
+import kotlinx.coroutines.launch
+
+
+internal class AcceptInviteUseCase(
+    private val keyserverUrl: String,
+    private val getPendingJsonRpcHistoryEntryByIdUseCase: GetPendingJsonRpcHistoryEntryByIdUseCase,
+    private val logger: Logger,
+    private val invitesRepository: InvitesStorageRepository,
+    private val keyManagementRepository: KeyManagementRepository,
+    private val identitiesInteractor: IdentitiesInteractor,
+    private val jsonRpcInteractor: JsonRpcInteractorInterface,
+    private val threadsRepository: ThreadsStorageRepository,
+) : AcceptInviteUseCaseInterface {
+    private fun AccountId.getInviteTag(): String = "$SELF_INVITE_PUBLIC_KEY_CONTEXT${this.value}"
+
+    override fun accept(inviteId: Long, onSuccess: (String) -> Unit, onFailure: (Throwable) -> Unit) {
+        scope.launch {
+            try {
+                val jsonRpcHistoryEntry = getPendingJsonRpcHistoryEntryByIdUseCase(inviteId)
+
+                if (jsonRpcHistoryEntry == null) {
+                    logger.error(MissingInviteRequestException.message)
+                    return@launch onFailure(MissingInviteRequestException)
+                }
+
+                val invite = invitesRepository.getReceivedInviteByInviteId(inviteId)
+                val inviterPublicKey = invite.inviterPublicKey
+                val inviteeAccountId = invite.inviteeAccount
+                val inviterAccountId = invite.inviterAccount
+
+                val inviteePublicKey = keyManagementRepository.getPublicKey(inviteeAccountId.getInviteTag())
+                val symmetricKey = keyManagementRepository.generateSymmetricKeyFromKeyAgreement(inviteePublicKey, inviterPublicKey)
+                val acceptTopic = keyManagementRepository.getTopicFromKey(symmetricKey)
+                keyManagementRepository.setKey(symmetricKey, acceptTopic.value)
+
+                val publicKey = keyManagementRepository.generateAndStoreX25519KeyPair()
+                val (identityPublicKey, identityPrivateKey) = identitiesInteractor.getIdentityKeyPair(inviteeAccountId)
+
+                val didJwt = encodeDidJwt(
+                    identityPrivateKey,
+                    EncodeInviteApprovalDidJwtPayloadUseCase(publicKey, inviterAccountId),
+                    EncodeDidJwtPayloadUseCase.Params(identityPublicKey, keyserverUrl)
+                ).getOrElse() { error ->
+                    onFailure(error)
+                    return@launch
+                }
+
+                val acceptanceParams = CoreChatParams.AcceptanceParams(responseAuth = didJwt.value)
+                val responseParams = JsonRpcResponse.JsonRpcResult(jsonRpcHistoryEntry.id, result = acceptanceParams)
+                val irnParams = IrnParams(Tags.CHAT_INVITE_RESPONSE, Ttl(MONTH_IN_SECONDS))
+                jsonRpcInteractor.publishJsonRpcResponse(acceptTopic, irnParams, responseParams, {}, { error -> return@publishJsonRpcResponse onFailure(error) })
+
+                val threadSymmetricKey = keyManagementRepository.generateSymmetricKeyFromKeyAgreement(publicKey, inviterPublicKey)
+                val threadTopic = keyManagementRepository.getTopicFromKey(threadSymmetricKey)
+                keyManagementRepository.setKey(threadSymmetricKey, threadTopic.value)
+
+                threadsRepository.insertThread(threadTopic.value, selfAccount = inviteeAccountId.value, peerAccount = inviterAccountId.value)
+                invitesRepository.updateStatusByInviteId(inviteId, InviteStatus.APPROVED)
+
+                jsonRpcInteractor.subscribe(threadTopic) { error -> return@subscribe onFailure(error) }
+                onSuccess(threadTopic.value)
+
+            } catch (error: Exception) {
+                onFailure(error)
+            }
+        }
+    }
+}
+
+internal interface AcceptInviteUseCaseInterface {
+    fun accept(inviteId: Long, onSuccess: (String) -> Unit, onFailure: (Throwable) -> Unit)
+}


### PR DESCRIPTION
Draft as it's not ready but showcases the idea on how to integrate, one way, sync -> chat interaction

Main takeaways: 
- Chat engine listens for sync protocol updates/events on specific stores. Whenever they happen a particular chat use-case is invoked as if it received the event from the chat client call

What's missing:
- Integration when chat client calls needs to invoke sync updates