### PR TITLE
fix: unusable master key

### DIFF
--- a/androidCore/sdk/src/main/kotlin/com/walletconnect/android/internal/common/di/CoreCryptoModule.kt
+++ b/androidCore/sdk/src/main/kotlin/com/walletconnect/android/internal/common/di/CoreCryptoModule.kt
@@ -75,8 +75,8 @@ internal fun coreCryptoModule() = module {
             createSharedPreferences()
         } catch (e: Exception) {
             get<Logger>(named(AndroidCommonDITags.LOGGER)).error(e)
-            deleteSharedPreferences()
             deleteMasterKey()
+            deleteSharedPreferences()
             deleteDatabases()
             createSharedPreferences()
         }


### PR DESCRIPTION
Based on the GitHub discussion it might be helpful to delete the master key first, before deleting encrypted shared prefs and DB.

Source: https://github.com/google/tink/issues/535#issuecomment-912170221 