### PR TITLE
fix: Fix clearing inviteTopic on consequent registers

### DIFF
--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/client/ChatProtocol.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/client/ChatProtocol.kt
@@ -80,7 +80,7 @@ internal class ChatProtocol : ChatInterface {
 
     @Throws(IllegalStateException::class)
     override fun invite(invite: Chat.Params.Invite, onSuccess: (Long) -> Unit, onError: (Chat.Model.Error) -> Unit) = protocolFunction(onError) {
-        chatEngine.invite(invite.toCommon(), { inviteId -> onSuccess(inviteId) }, { error -> onError(Chat.Model.Error(error)) })
+        scope.launch { chatEngine.invite(invite.toCommon(), { inviteId -> onSuccess(inviteId) }, { error -> onError(Chat.Model.Error(error)) }) }
     }
 
     @Throws(IllegalStateException::class)

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/domain/ChatEngine.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/domain/ChatEngine.kt
@@ -24,8 +24,11 @@ import com.walletconnect.chat.engine.use_case.responses.OnLeaveResponseUseCase
 import com.walletconnect.chat.engine.use_case.responses.OnMessageResponseUseCase
 import com.walletconnect.chat.json_rpc.JsonRpcMethod
 import com.walletconnect.foundation.common.model.Ttl
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 
 internal class ChatEngine(
     private val jsonRpcInteractor: JsonRpcInteractorInterface,
@@ -94,7 +97,7 @@ internal class ChatEngine(
             .onEach { isAvailable -> _events.emit(ConnectionState(isAvailable)) }
             .filter { isAvailable: Boolean -> isAvailable }
             .onEach {
-                subscribeToChatTopicsUseCase()
+                coroutineScope { launch(Dispatchers.IO) { subscribeToChatTopicsUseCase() } }
 
                 if (jsonRpcRequestsJob == null) jsonRpcRequestsJob = collectJsonRpcRequests()
                 if (jsonRpcResponsesJob == null) jsonRpcResponsesJob = collectPeerResponses()

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/SubscribeToChatTopicsUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/SubscribeToChatTopicsUseCase.kt
@@ -8,8 +8,6 @@ import com.walletconnect.chat.storage.InvitesStorageRepository
 import com.walletconnect.chat.storage.ThreadsStorageRepository
 import com.walletconnect.foundation.common.model.Topic
 import com.walletconnect.foundation.util.Logger
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -26,13 +24,9 @@ internal class SubscribeToChatTopicsUseCase(
     val errors: SharedFlow<SDKError> = _errors.asSharedFlow()
 
     suspend operator fun invoke() {
-        coroutineScope {
-            launch(Dispatchers.IO) {
-                trySubscribeToInviteTopics()
-                trySubscribeToPendingAcceptTopics()
-                trySubscribeToThreadTopics()
-            }
-        }
+        trySubscribeToInviteTopics()
+        trySubscribeToPendingAcceptTopics()
+        trySubscribeToThreadTopics()
     }
 
     private suspend fun trySubscribeToInviteTopics() = accountsRepository.getAllInviteTopics()

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/requests/OnInviteRequestUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/requests/OnInviteRequestUseCase.kt
@@ -4,7 +4,6 @@ import com.walletconnect.android.internal.common.crypto.kmr.KeyManagementReposit
 import com.walletconnect.android.internal.common.jwt.did.extractVerifiedDidJwtClaims
 import com.walletconnect.android.internal.common.model.WCRequest
 import com.walletconnect.android.internal.common.model.type.EngineEvent
-import com.walletconnect.android.internal.common.scope
 import com.walletconnect.android.keyserver.domain.IdentitiesInteractor
 import com.walletconnect.chat.common.exceptions.AccountsAlreadyHaveInviteException
 import com.walletconnect.chat.common.exceptions.AccountsAlreadyHaveThreadException
@@ -24,8 +23,6 @@ import com.walletconnect.utils.extractTimestamp
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 internal class OnInviteRequestUseCase(
     private val logger: Logger,
@@ -38,36 +35,33 @@ internal class OnInviteRequestUseCase(
     private val _events: MutableSharedFlow<EngineEvent> = MutableSharedFlow()
     val events: SharedFlow<EngineEvent> = _events.asSharedFlow()
 
-    operator fun invoke(wcRequest: WCRequest, params: ChatParams.InviteParams) {
-        val claims = extractVerifiedDidJwtClaims<ChatDidJwtClaims.InviteProposal>(params.inviteAuth).getOrElse() { error -> return@invoke logger.error(error) }
+    suspend operator fun invoke(wcRequest: WCRequest, params: ChatParams.InviteParams) {
+        val claims = extractVerifiedDidJwtClaims<ChatDidJwtClaims.InviteProposal>(params.inviteAuth).getOrElse() { error -> return logger.error(error) }
         if (claims.action != ChatDidJwtClaims.InviteProposal.ACT) return logger.error(InvalidActClaims(ChatDidJwtClaims.InviteProposal.ACT))
 
-        scope.launch {
-            val inviterAccountId = identitiesInteractor.resolveIdentityDidKey(claims.issuer).getOrElse() { error -> return@launch logger.error(error) }
+        val inviterAccountId = identitiesInteractor.resolveIdentityDidKey(claims.issuer).getOrElse() { error -> return logger.error(error) }
 
-            runCatching { accountsRepository.getAccountByInviteTopic(wcRequest.topic) }.fold(onSuccess = { inviteeAccount ->
-                if (runBlocking(scope.coroutineContext) { invitesRepository.checkIfAccountsHaveExistingInvite(inviterAccountId.value, inviteeAccount.accountId.value) }) {
-                    return@launch logger.error(AccountsAlreadyHaveInviteException)
-                }
+        runCatching { accountsRepository.getAccountByInviteTopic(wcRequest.topic) }.fold(onSuccess = { inviteeAccount ->
+            if (invitesRepository.checkIfAccountsHaveExistingInvite(inviterAccountId.value, inviteeAccount.accountId.value)) {
+                return logger.error(AccountsAlreadyHaveInviteException)
+            }
 
-                if (runBlocking(scope.coroutineContext) { threadsRepository.checkIfSelfAccountHaveThreadWithPeerAccount(inviteeAccount.accountId.value, inviterAccountId.value) }) {
-                    return@launch logger.error(AccountsAlreadyHaveThreadException)
-                }
+            if (threadsRepository.checkIfSelfAccountHaveThreadWithPeerAccount(inviteeAccount.accountId.value, inviterAccountId.value)) {
+                return logger.error(AccountsAlreadyHaveThreadException)
+            }
 
-                val inviteePublicKey = inviteeAccount.publicInviteKey ?: throw Throwable("Missing publicInviteKey")
-                val inviterPublicKey = decodeX25519DidKey(claims.inviterPublicKey)
-                val symmetricKey = keyManagementRepository.generateSymmetricKeyFromKeyAgreement(inviteePublicKey, inviterPublicKey)
-                val acceptTopic = keyManagementRepository.getTopicFromKey(symmetricKey)
-                val invite = Invite.Received(
-                    wcRequest.id, inviterAccountId, inviteeAccount.accountId, InviteMessage(claims.subject),
-                    inviterPublicKey, InviteStatus.PENDING, acceptTopic, symmetricKey, inviterPrivateKey = null,
-                    //todo: use publishedAt from relay https://github.com/WalletConnect/WalletConnectKotlinV2/issues/872
-                    timestamp = wcRequest.id.extractTimestamp()
-                )
+            val inviteePublicKey = inviteeAccount.publicInviteKey ?: throw Throwable("Missing publicInviteKey")
+            val inviterPublicKey = decodeX25519DidKey(claims.inviterPublicKey)
+            val symmetricKey = keyManagementRepository.generateSymmetricKeyFromKeyAgreement(inviteePublicKey, inviterPublicKey)
+            val acceptTopic = keyManagementRepository.getTopicFromKey(symmetricKey)
+            val invite = Invite.Received(
+                wcRequest.id, inviterAccountId, inviteeAccount.accountId, InviteMessage(claims.subject), inviterPublicKey, InviteStatus.PENDING, acceptTopic, symmetricKey, inviterPrivateKey = null,
+                //todo: use publishedAt from relay https://github.com/WalletConnect/WalletConnectKotlinV2/issues/872
+                timestamp = wcRequest.id.extractTimestamp()
+            )
 
-                invitesRepository.insertInvite(invite)
-                _events.emit(Events.OnInvite(invite))
-            }, onFailure = { error -> logger.error(error) })
-        }
+            invitesRepository.insertInvite(invite)
+            _events.emit(Events.OnInvite(invite))
+        }, onFailure = { error -> logger.error(error) })
     }
 }

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/requests/OnInviteRequestUseCase.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/engine/use_case/requests/OnInviteRequestUseCase.kt
@@ -50,7 +50,7 @@ internal class OnInviteRequestUseCase(
                     return@launch logger.error(AccountsAlreadyHaveInviteException)
                 }
 
-                if (runBlocking(scope.coroutineContext) { threadsRepository.checkIfAccountsHaveExistingThread(inviterAccountId.value, inviteeAccount.accountId.value) }) {
+                if (runBlocking(scope.coroutineContext) { threadsRepository.checkIfSelfAccountHaveThreadWithPeerAccount(inviteeAccount.accountId.value, inviterAccountId.value) }) {
                     return@launch logger.error(AccountsAlreadyHaveThreadException)
                 }
 

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/storage/AccountsStorageRepository.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/storage/AccountsStorageRepository.kt
@@ -18,7 +18,7 @@ internal class AccountsStorageRepository(private val accounts: AccountsQueries) 
         }
 
     private suspend fun updateAccount(account: Account) = with(account) {
-        accounts.updateAccount(publicIdentityKey.keyAsHex, publicInviteKey?.keyAsHex, inviteTopic?.value, accountId.value)
+        accounts.updateAccount(publicIdentityKey.keyAsHex, accountId.value)
     }
 
     private suspend fun createAccount(account: Account) = with(account) {

--- a/chat/sdk/src/main/kotlin/com/walletconnect/chat/storage/ThreadsStorageRepository.kt
+++ b/chat/sdk/src/main/kotlin/com/walletconnect/chat/storage/ThreadsStorageRepository.kt
@@ -10,9 +10,8 @@ internal class ThreadsStorageRepository(private val threads: ThreadsQueries) {
 
     suspend fun getThreadsForSelfAccount(account: String): List<Thread> = threads.getThreadsForSelfAccount(account, ::dbToThread).executeAsList()
 
-    suspend fun checkIfAccountsHaveExistingThread(accountOne: String, accountTwo: String): Boolean =
-        threads.checkIfAccountsHaveExistingThread(accountOne, accountTwo).executeAsOne()
-                || threads.checkIfAccountsHaveExistingThread(accountTwo, accountOne).executeAsOne()
+    suspend fun checkIfSelfAccountHaveThreadWithPeerAccount(selfAccount: String, peerAccount: String): Boolean =
+        threads.checkIfSelfAccountHaveThreadWithPeerAccount(selfAccount, peerAccount).executeAsOne()
 
     suspend fun deleteThreadByTopic(topic: String) = threads.deleteThreadByTopic(topic)
 

--- a/chat/sdk/src/main/sqldelight/com/walletconnect/chat/storage/data/dao/Accounts.sq
+++ b/chat/sdk/src/main/sqldelight/com/walletconnect/chat/storage/data/dao/Accounts.sq
@@ -31,7 +31,7 @@ WHERE accountId = ?;
 
 updateAccount:
 UPDATE Accounts
-SET publicIdentityKey = ?, publicInviteKey = ?, inviteTopic = ?
+SET publicIdentityKey = ?
 WHERE accountId = ?;
 
 getAllInviteTopics:

--- a/chat/sdk/src/main/sqldelight/com/walletconnect/chat/storage/data/dao/Threads.sq
+++ b/chat/sdk/src/main/sqldelight/com/walletconnect/chat/storage/data/dao/Threads.sq
@@ -15,7 +15,7 @@ SELECT topic, selfAccount, peerAccount
 FROM Threads
 WHERE selfAccount = ?;
 
-checkIfAccountsHaveExistingThread:
+checkIfSelfAccountHaveThreadWithPeerAccount:
 SELECT EXISTS (
     SELECT 1
     FROM Threads


### PR DESCRIPTION
Issue: When calling register second time with the same account, Account entry was updated with null inviteTopic and invitePublic key, disabling listening for incoming invites