### PR TITLE
[W3W Sample] Connections Screen

### DIFF
--- a/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/ui/Web3WalletNavGraph.kt
+++ b/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/ui/Web3WalletNavGraph.kt
@@ -51,10 +51,8 @@ fun Web3WalletNavGraph(
     connectionsViewModel: ConnectionsViewModel,
     getStartedVisited: Boolean,
     modifier: Modifier = Modifier,
-    startDestination: String = if (getStartedVisited) Route.Inbox.path else Route.GetStarted.path,
+    startDestination: String = if (getStartedVisited) Route.Connections.path else Route.GetStarted.path,
 ) {
-    Timber.d("Web3WalletNavGraph: ${navController.currentBackStackEntry?.destination?.route}")
-
     var scrimColor by remember { mutableStateOf(Color.Unspecified) }
 
     ModalBottomSheetLayout(

--- a/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/ui/routes/composable_routes/connection_details/ConnectionDetailsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/ui/routes/composable_routes/connection_details/ConnectionDetailsRoute.kt
@@ -124,7 +124,7 @@ fun Namespace(namespaces: Map<String, Wallet.Model.Namespace.Session>) {
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         HorizontalPager(
-            modifier = Modifier.height(500.dp),
+            modifier = Modifier.height(450.dp),
             count = accounts.size,
             state = pagerState,
         ) { current ->

--- a/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/ui/routes/composable_routes/connections/ConnectionsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/ui/routes/composable_routes/connections/ConnectionsRoute.kt
@@ -35,10 +35,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstrainedLayoutReference
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.ConstraintLayoutScope
-import androidx.constraintlayout.compose.Dimension
 import androidx.navigation.NavController
 import com.skydoves.landscapist.glide.GlideImage
 import com.walletconnect.sample.common.ui.TopBarActionImage
@@ -61,79 +57,27 @@ fun ConnectionsRoute(navController: NavController, connectionsViewModel: Connect
     connectionsViewModel.refreshConnections()
     val connections by connectionsViewModel.connections.collectAsState(initial = emptyList())
 
-    ConstraintLayout(modifier = Modifier.fillMaxSize()) {
-        val (title, content, buttons) = createRefs()
-        Title(title)
-        Connections(connections, content, title, buttons) { connectionUI -> navController.navigate("${Route.ConnectionDetails.path}/${connectionUI.id}") }
-        Buttons(navController, buttons)
+    Column(modifier = Modifier.fillMaxSize()) {
+        Title(navController)
+        Connections(connections) { connectionUI -> navController.navigate("${Route.ConnectionDetails.path}/${connectionUI.id}") }
     }
 }
 
 @Composable
-fun ConstraintLayoutScope.Title(titleRef: ConstrainedLayoutReference) {
-    Column(modifier = Modifier.constrainAs(titleRef) {
-        top.linkTo(parent.top, margin = 0.dp)
-        start.linkTo(parent.start)
-    }) {
-        WCTopAppBar(titleText = "Connections", TopBarActionImage(R.drawable.ic_copy, {}), TopBarActionImage(R.drawable.ic_qr_code, {}))
-    }
+fun Title(navController: NavController) {
+    WCTopAppBar(
+        titleText = "Connections",
+        TopBarActionImage(R.drawable.ic_copy) { navController.navigate(Route.PasteUri.path) },
+        TopBarActionImage(R.drawable.ic_qr_code) { navController.navigate(Route.ScanUri.path) }
+    )
 }
 
 @Composable
-fun ConstraintLayoutScope.Buttons(navController: NavController, buttonsRef: ConstrainedLayoutReference) {
-    val iconTint = Color(0xFFFFFFFF)
-    Column(modifier = Modifier.constrainAs(buttonsRef) {
-        bottom.linkTo(parent.bottom, margin = 10.dp)
-        start.linkTo(parent.start)
-        end.linkTo(parent.end)
-    }) {
-        Row {
-            Spacer(modifier = Modifier.width(20.dp))
-            ConnectionsButton(
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .clickable {
-                        navController.navigate(Route.Inbox.path)
-                    }
-            ) {
-                Icon(imageVector = ImageVector.vectorResource(id = R.drawable.ic_notification), contentDescription = "Notifications Icon", tint = iconTint)
-            }
-            Spacer(modifier = Modifier.weight(1.0f))
-            ConnectionsButton(modifier = Modifier
-                .clip(CircleShape)
-                .clickable {
-                    navController.navigate(Route.PasteUri.path)
-                }) {
-                Icon(imageVector = ImageVector.vectorResource(id = R.drawable.ic_copy), contentDescription = "Paste Uri Icon", tint = iconTint)
-            }
-            Spacer(modifier = Modifier.width(20.dp))
-            ConnectionsButton(modifier = Modifier
-                .clip(CircleShape)
-                .clickable {
-                    navController.navigate(Route.ScanUri.path)
-                }) {
-                Icon(imageVector = ImageVector.vectorResource(id = R.drawable.ic_qr_code), contentDescription = "Scan QRCode Icon", tint = iconTint)
-            }
-            Spacer(modifier = Modifier.width(20.dp))
-        }
-    }
-}
-
-@Composable
-fun ConstraintLayoutScope.Connections(
+fun Connections(
     connections: List<ConnectionUI>,
-    contentRef: ConstrainedLayoutReference,
-    titleRef: ConstrainedLayoutReference,
-    buttonsRef: ConstrainedLayoutReference,
     onClick: (ConnectionUI) -> Unit = {},
 ) {
-    val modifier = Modifier.constrainAs(contentRef) {
-        top.linkTo(titleRef.bottom)
-        start.linkTo(parent.start)
-        end.linkTo(parent.end)
-        bottom.linkTo(buttonsRef.top)
-        height = Dimension.fillToConstraints
-    }
+    val modifier = Modifier.fillMaxHeight()
     if (connections.isEmpty()) {
         NoConnections(modifier)
     } else {
@@ -217,7 +161,7 @@ fun Connection(
 @Composable
 fun NoConnections(modifier: Modifier) {
     val contentColor = Color(if (isSystemInDarkTheme()) 0xFF585F5F else 0xFF9EA9A9)
-    Column(modifier = modifier.fillMaxHeight(), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(modifier = Modifier.weight(1f))
         Icon(
             tint = contentColor,


### PR DESCRIPTION
Didn't had enough capacity to bring connections screen to current design. Will come back to full implementation later. This PR only cleanups unnecessary buttons and adjust views to bottom bar

<img width="449" alt="Screenshot 2023-10-11 at 13 11 48" src="https://github.com/WalletConnect/WalletConnectKotlinV2/assets/23137643/6f5648ca-a26a-4d92-9565-d54b61a5f946">
<img width="448" alt="Screenshot 2023-10-11 at 13 11 33" src="https://github.com/WalletConnect/WalletConnectKotlinV2/assets/23137643/963976e0-3386-43b5-9b3b-cb01104af15a">
