### PR TITLE
ci: update to latest version of checkout action

### DIFF
--- a/.github/actions/ci_relay/action.yml
+++ b/.github/actions/ci_relay/action.yml
@@ -17,7 +17,7 @@ runs:
         architecture: x86_64
         cache: 'gradle'
     - name: Cache Gradle packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/actions/ci_relay/action.yml
+++ b/.github/actions/ci_relay/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '17'

--- a/.github/actions/ci_setup/action.yml
+++ b/.github/actions/ci_setup/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '17'

--- a/.github/workflows/ci_assemble.yml
+++ b/.github/workflows/ci_assemble.yml
@@ -29,7 +29,7 @@ jobs:
           architecture: x86_64
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_assemble.yml
+++ b/.github/workflows/ci_assemble.yml
@@ -19,10 +19,10 @@ jobs:
   build_sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/ci_db_migrations.yml
+++ b/.github/workflows/ci_db_migrations.yml
@@ -39,7 +39,7 @@ jobs:
           architecture: x86_64
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_db_migrations.yml
+++ b/.github/workflows/ci_db_migrations.yml
@@ -29,10 +29,10 @@ jobs:
     name: ${{ matrix.conf.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/ci_debug_sample.yml
+++ b/.github/workflows/ci_debug_sample.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'gradle'
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_debug_sample.yml
+++ b/.github/workflows/ci_debug_sample.yml
@@ -15,10 +15,10 @@ jobs:
     name: ${{ matrix.conf.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/ci_instrumented_tests.yml
+++ b/.github/workflows/ci_instrumented_tests.yml
@@ -33,7 +33,7 @@ jobs:
     name: Run Instrumented Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci_internal_sample.yml
+++ b/.github/workflows/ci_internal_sample.yml
@@ -35,7 +35,7 @@ jobs:
           cache: 'gradle'
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_internal_sample.yml
+++ b/.github/workflows/ci_internal_sample.yml
@@ -24,10 +24,10 @@ jobs:
     name: ${{ matrix.conf.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/ci_record_snapshots.yml
+++ b/.github/workflows/ci_record_snapshots.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'gradle'
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_record_snapshots.yml
+++ b/.github/workflows/ci_record_snapshots.yml
@@ -13,10 +13,10 @@ jobs:
     name: ${{ matrix.conf.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/ci_relay.yml
+++ b/.github/workflows/ci_relay.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Relay CI
         env:

--- a/.github/workflows/ci_release_sample.yml
+++ b/.github/workflows/ci_release_sample.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'gradle'
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_release_sample.yml
+++ b/.github/workflows/ci_release_sample.yml
@@ -16,10 +16,10 @@ jobs:
     name: ${{ matrix.conf.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Relay CI
         env:
@@ -46,7 +46,7 @@ jobs:
 #     name: ${{ matrix.conf.name }}
 #     runs-on: self-hosted
 #     steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 
 #       - name: Run instrumented tests
 #         uses: ./.github/actions/ci_instrumented_tests
@@ -65,7 +65,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -23,10 +23,10 @@ jobs:
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -32,14 +32,14 @@ jobs:
           distribution: 'zulu'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/ci_verify_snapshots.yml
+++ b/.github/workflows/ci_verify_snapshots.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'gradle'
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci_verify_snapshots.yml
+++ b/.github/workflows/ci_verify_snapshots.yml
@@ -13,10 +13,10 @@ jobs:
     name: ${{ matrix.conf.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'


### PR DESCRIPTION
## Summary
 - Upgrade checkout action to `v4` (`v3` is deprecated)

## Testing Plan
 - Check `Node.js 16` warning messages go away after next assemble job run