### PR TITLE
Remove .org fallback

### DIFF
--- a/.github/workflows/ci_relay.yml
+++ b/.github/workflows/ci_relay.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run Relay CI
         env:
-          TEST_RELAY_URL: wss://relay.walletconnect.com
+          TEST_RELAY_URL: wss://relay.walletconnect.org
           TEST_PROJECT_ID: ${{ secrets.WC_CLOUD_PROJECT_ID }}
           NOTIFY_INTEGRATION_TESTS_PROJECT_ID: ${{ secrets.NOTIFY_INTEGRATION_TESTS_PROJECT_ID }}
           NOTIFY_INTEGRATION_TESTS_SECRET: ${{ secrets.NOTIFY_INTEGRATION_TESTS_SECRET }}

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run Relay CI
         env:
-          TEST_RELAY_URL: wss://relay.walletconnect.com
+          TEST_RELAY_URL: wss://relay.walletconnect.org
           TEST_PROJECT_ID: ${{ secrets.WC_CLOUD_PROJECT_ID }}
         with:
           SECRETS_PROPERTIES: ${{ secrets.SECRETS_PROPERTIES }}

--- a/core/android/src/androidTest/kotlin/com/walletconnect/android/test/activity/WCInstrumentedActivityScenario.kt
+++ b/core/android/src/androidTest/kotlin/com/walletconnect/android/test/activity/WCInstrumentedActivityScenario.kt
@@ -82,7 +82,7 @@ class WCInstrumentedActivityScenario : TestRule {
                     }
                 }
             }.fold(
-                onSuccess = { Timber.d("Connection established with: ${TestClient.RELAY_URL}") },
+                onSuccess = { Timber.d("Connection established with successfully") },
                 onFailure = { fail("Unable to establish connection within $timeoutDuration") }
             )
 

--- a/core/android/src/androidTest/kotlin/com/walletconnect/android/test/utils/TestClient.kt
+++ b/core/android/src/androidTest/kotlin/com/walletconnect/android/test/utils/TestClient.kt
@@ -21,7 +21,6 @@ import org.koin.core.qualifier.named
 import timber.log.Timber
 
 internal object TestClient {
-    const val RELAY_URL = "wss://relay.walletconnect.com?projectId=${BuildConfig.PROJECT_ID}"
     private val app = ApplicationProvider.getApplicationContext<Application>()
     fun KoinApplication.Companion.createNewWCKoinApp(): KoinApplication = KoinApplication.init().apply { createEagerInstances() }
 
@@ -40,7 +39,7 @@ internal object TestClient {
 
         private val coreProtocol = CoreClient.apply {
             Timber.d("Primary CP start: ")
-            initialize(metadata, RELAY_URL, ConnectionType.MANUAL, app, onError = ::globalOnError)
+            initialize(app, BuildConfig.PROJECT_ID, metadata, ConnectionType.MANUAL, onError = ::globalOnError)
             Relay.connect(::globalOnError)
             _isInitialized.tryEmit(true)
             Timber.d("Primary CP finish: ")
@@ -72,7 +71,7 @@ internal object TestClient {
 
         private val coreProtocol = CoreProtocol(secondaryKoinApp).apply {
             Timber.d("Secondary CP start: ")
-            initialize(metadata, RELAY_URL, ConnectionType.MANUAL, app) { Timber.e(it.throwable) }
+            initialize(app, BuildConfig.PROJECT_ID, metadata, ConnectionType.MANUAL) { Timber.e(it.throwable) }
 
             // Override of previous Relay necessary for reinitialization of `eventsFlow`
             Relay = RelayClient(secondaryKoinApp)
@@ -91,8 +90,5 @@ internal object TestClient {
         }
 
         internal val Relay get() = coreProtocol.Relay
-        internal val jsonRpcInteractor: JsonRpcInteractorInterface by lazy { secondaryKoinApp.koin.get() }
-        internal val keyManagementRepository: KeyManagementRepository by lazy { secondaryKoinApp.koin.get() }
-
     }
 }

--- a/core/android/src/main/kotlin/com/walletconnect/android/CoreInterface.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/CoreInterface.kt
@@ -27,8 +27,20 @@ interface CoreInterface {
     fun initialize(
         metaData: Core.Model.AppMetaData,
         relayServerUrl: String,
-        connectionType: ConnectionType,
+        connectionType: ConnectionType = ConnectionType.AUTOMATIC,
         application: Application,
+        relay: RelayConnectionInterface? = null,
+        keyServerUrl: String? = null,
+        networkClientTimeout: NetworkClientTimeout? = null,
+        telemetryEnabled: Boolean = true,
+        onError: (Core.Model.Error) -> Unit,
+    )
+
+    fun initialize(
+        application: Application,
+        projectId: String,
+        metaData: Core.Model.AppMetaData,
+        connectionType: ConnectionType = ConnectionType.AUTOMATIC,
         relay: RelayConnectionInterface? = null,
         keyServerUrl: String? = null,
         networkClientTimeout: NetworkClientTimeout? = null,

--- a/core/android/src/main/kotlin/com/walletconnect/android/CoreProtocol.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/CoreProtocol.kt
@@ -76,44 +76,103 @@ class CoreProtocol(private val koinApp: KoinApplication = wcKoinApp) : CoreInter
         onError: (Core.Model.Error) -> Unit
     ) {
         try {
-            val bundleId: String = application.packageName
-            with(koinApp) {
-                androidContext(application)
-                require(relayServerUrl.isValidRelayServerUrl()) { "Check the schema and projectId parameter of the Server Url" }
-                modules(
-                    module { single { ProjectId(relayServerUrl.projectId()) } },
-                    module { single(named(AndroidCommonDITags.TELEMETRY_ENABLED)) { TelemetryEnabled(telemetryEnabled) } },
-                    coreAndroidNetworkModule(relayServerUrl, connectionType.toCommonConnectionType(), BuildConfig.SDK_VERSION, networkClientTimeout, bundleId),
-                    coreCommonModule(),
-                    coreCryptoModule(),
-                )
+            require(relayServerUrl.isValidRelayServerUrl()) { "Check the schema and projectId parameter of the Server Url" }
 
-                if (relay == null) {
-                    Relay.initialize { error -> onError(Core.Model.Error(error)) }
-                }
-
-                modules(
-                    coreStorageModule(bundleId = bundleId),
-                    pushModule(),
-                    module { single { relay ?: Relay } },
-                    module { single { with(metaData) { AppMetaData(name = name, description = description, url = url, icons = icons, redirect = Redirect(redirect)) } } },
-                    module { single { Echo } },
-                    module { single { Push } },
-                    module { single { Verify } },
-                    coreJsonRpcModule(),
-                    corePairingModule(Pairing, PairingController),
-                    keyServerModule(keyServerUrl),
-                    explorerModule(),
-                    web3ModalModule(),
-                    pulseModule(bundleId)
-                )
-            }
-
-            Verify.initialize()
-            Pairing.initialize()
-            PairingController.initialize()
+            setup(
+                application = application,
+                serverUrl = relayServerUrl,
+                projectId = relayServerUrl.projectId(),
+                telemetryEnabled = telemetryEnabled,
+                connectionType = connectionType,
+                networkClientTimeout = networkClientTimeout,
+                relay = relay,
+                onError = onError,
+                metaData = metaData,
+                keyServerUrl = keyServerUrl
+            )
         } catch (e: Exception) {
             onError(Core.Model.Error(e))
         }
+    }
+
+    override fun initialize(
+        application: Application,
+        projectId: String,
+        metaData: Core.Model.AppMetaData,
+        connectionType: ConnectionType,
+        relay: RelayConnectionInterface?,
+        keyServerUrl: String?,
+        networkClientTimeout: NetworkClientTimeout?,
+        telemetryEnabled: Boolean,
+        onError: (Core.Model.Error) -> Unit
+    ) {
+        try {
+            require(projectId.isEmpty()) { "Project Id cannot be empty" }
+
+            setup(
+                application = application,
+                projectId = projectId,
+                telemetryEnabled = telemetryEnabled,
+                connectionType = connectionType,
+                networkClientTimeout = networkClientTimeout,
+                relay = relay,
+                onError = onError,
+                metaData = metaData,
+                keyServerUrl = keyServerUrl
+            )
+        } catch (e: Exception) {
+            onError(Core.Model.Error(e))
+        }
+    }
+
+    private fun CoreProtocol.setup(
+        application: Application,
+        serverUrl: String? = null,
+        projectId: String,
+        telemetryEnabled: Boolean,
+        connectionType: ConnectionType,
+        networkClientTimeout: NetworkClientTimeout?,
+        relay: RelayConnectionInterface?,
+        onError: (Core.Model.Error) -> Unit,
+        metaData: Core.Model.AppMetaData,
+        keyServerUrl: String?
+    ) {
+        val bundleId: String = application.packageName
+        val relayServerUrl = if (serverUrl.isNullOrEmpty()) "wss://relay.walletconnect.org?projectId=$projectId" else serverUrl
+
+        with(koinApp) {
+            androidContext(application)
+            modules(
+                module { single { ProjectId(projectId) } },
+                module { single(named(AndroidCommonDITags.TELEMETRY_ENABLED)) { TelemetryEnabled(telemetryEnabled) } },
+                coreAndroidNetworkModule(relayServerUrl, connectionType.toCommonConnectionType(), BuildConfig.SDK_VERSION, networkClientTimeout, bundleId),
+                coreCommonModule(),
+                coreCryptoModule(),
+            )
+
+            if (relay == null) {
+                Relay.initialize { error -> onError(Core.Model.Error(error)) }
+            }
+
+            modules(
+                coreStorageModule(bundleId = bundleId),
+                pushModule(),
+                module { single { relay ?: Relay } },
+                module { single { with(metaData) { AppMetaData(name = name, description = description, url = url, icons = icons, redirect = Redirect(redirect)) } } },
+                module { single { Echo } },
+                module { single { Push } },
+                module { single { Verify } },
+                coreJsonRpcModule(),
+                corePairingModule(Pairing, PairingController),
+                keyServerModule(keyServerUrl),
+                explorerModule(),
+                web3ModalModule(),
+                pulseModule(bundleId)
+            )
+        }
+
+        Verify.initialize()
+        Pairing.initialize()
+        PairingController.initialize()
     }
 }

--- a/core/android/src/main/kotlin/com/walletconnect/android/CoreProtocol.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/CoreProtocol.kt
@@ -107,7 +107,7 @@ class CoreProtocol(private val koinApp: KoinApplication = wcKoinApp) : CoreInter
         onError: (Core.Model.Error) -> Unit
     ) {
         try {
-            require(projectId.isEmpty()) { "Project Id cannot be empty" }
+            require(projectId.isNotEmpty()) { "Project Id cannot be empty" }
 
             setup(
                 application = application,

--- a/core/android/src/main/kotlin/com/walletconnect/android/relay/NetworkClientTimeout.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/relay/NetworkClientTimeout.kt
@@ -20,7 +20,7 @@ data class NetworkClientTimeout(
 
     companion object {
 
-        private const val MIN_TIMEOUT_LIMIT_AS_MILLIS = 5_000L
+        private const val MIN_TIMEOUT_LIMIT_AS_MILLIS = 10_000L
         private const val MAX_TIMEOUT_LIMIT_AS_MILLIS = 60_000L
 
         fun getDefaultTimeout() = NetworkClientTimeout(

--- a/core/android/src/main/kotlin/com/walletconnect/android/relay/NetworkClientTimeout.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/relay/NetworkClientTimeout.kt
@@ -24,7 +24,7 @@ data class NetworkClientTimeout(
         private const val MAX_TIMEOUT_LIMIT_AS_MILLIS = 60_000L
 
         fun getDefaultTimeout() = NetworkClientTimeout(
-            timeout = MAX_TIMEOUT_LIMIT_AS_MILLIS,
+            timeout = MIN_TIMEOUT_LIMIT_AS_MILLIS,
             timeUnit = TimeUnit.MILLISECONDS
         )
     }

--- a/core/android/src/test/kotlin/com/walletconnect/android/internal/common/ClientIdJwtRepositoryAndroidTest.kt
+++ b/core/android/src/test/kotlin/com/walletconnect/android/internal/common/ClientIdJwtRepositoryAndroidTest.kt
@@ -18,7 +18,7 @@ internal class ClientIdJwtRepositoryAndroidTest {
     private val keyChain = KeyChainMock()
     private val sut = spyk(ClientIdJwtRepositoryAndroid(keyChain))
     private val tag = "key_did_keypair"
-    private val serverUrl = "wss://relay.walletconnect.com"
+    private val serverUrl = "wss://relay.walletconnect.org"
 
     // Expected JWT for given nonce
     private val expectedJWT =

--- a/foundation/src/test/kotlin/com/walletconnect/foundation/crypto/data/repository/ClientIdJwtRepositoryTest.kt
+++ b/foundation/src/test/kotlin/com/walletconnect/foundation/crypto/data/repository/ClientIdJwtRepositoryTest.kt
@@ -19,7 +19,7 @@ internal class ClientIdJwtRepositoryTest {
             return "884ab67f787b69e534bfdba8d5beb4e719700e90ac06317ed177d49e5a33be5a" to "58e0254c211b858ef7896b00e3f36beeb13d568d47c6031c4218b87718061295"
         }
     })
-    private val serverUrl = "wss://relay.walletconnect.com"
+    private val serverUrl = "wss://relay.walletconnect.org"
 
     // Expected JWT for given nonce
     private val expectedJWT =

--- a/protocol/sign/src/androidTest/kotlin/com/walletconnect/sign/test/scenario/HybridAppInstrumentedActivityScenario.kt
+++ b/protocol/sign/src/androidTest/kotlin/com/walletconnect/sign/test/scenario/HybridAppInstrumentedActivityScenario.kt
@@ -69,7 +69,7 @@ class HybridAppInstrumentedActivityScenario : TestRule, SignActivityScenario() {
                     }
                 }
             }.fold(
-                onSuccess = { Timber.d("Connection established and peers initialized with: ${TestClient.RELAY_URL}") },
+                onSuccess = { Timber.d("Connection established and peers initialized successfully") },
                 onFailure = { TestCase.fail("Unable to establish connection OR initialize peers within $timeoutDuration") }
             )
 

--- a/protocol/sign/src/androidTest/kotlin/com/walletconnect/sign/test/scenario/SignClientInstrumentedActivityScenario.kt
+++ b/protocol/sign/src/androidTest/kotlin/com/walletconnect/sign/test/scenario/SignClientInstrumentedActivityScenario.kt
@@ -63,7 +63,7 @@ class SignClientInstrumentedActivityScenario : TestRule, SignActivityScenario() 
                     }
                 }
             }.fold(
-                onSuccess = { Timber.d("Connection established and peers initialized with: ${TestClient.RELAY_URL}") },
+                onSuccess = { Timber.d("Connection established and peers initialized successfully") },
                 onFailure = { fail("Unable to establish connection OR initialize peers within $timeoutDuration") }
             )
 

--- a/protocol/sign/src/androidTest/kotlin/com/walletconnect/sign/test/utils/TestClient.kt
+++ b/protocol/sign/src/androidTest/kotlin/com/walletconnect/sign/test/utils/TestClient.kt
@@ -18,7 +18,6 @@ import org.koin.core.KoinApplication
 import timber.log.Timber
 
 internal object TestClient {
-    const val RELAY_URL = "wss://relay.walletconnect.com?projectId=${BuildConfig.PROJECT_ID}"
     private val app = ApplicationProvider.getApplicationContext<Application>()
     fun KoinApplication.Companion.createNewWCKoinApp(): KoinApplication = init().apply { createEagerInstances() }
 
@@ -34,7 +33,7 @@ internal object TestClient {
 
         private val coreProtocol = CoreClient.apply {
             Timber.d("Wallet CP start: ")
-            initialize(metadata, RELAY_URL, ConnectionType.MANUAL, app, onError = ::globalOnError)
+            initialize(app, BuildConfig.PROJECT_ID, metadata, ConnectionType.MANUAL, onError = ::globalOnError)
             Relay.connect(::globalOnError)
         }
 
@@ -64,13 +63,23 @@ internal object TestClient {
 
         private val coreProtocol = CoreProtocol(dappKoinApp).apply {
             Timber.d("Dapp CP start: ")
-            initialize(metadata, RELAY_URL, ConnectionType.MANUAL, app) { Timber.e(it.throwable) }
+            initialize(app, BuildConfig.PROJECT_ID, metadata, ConnectionType.MANUAL) { Timber.e(it.throwable) }
 
             // Override of previous Relay necessary for reinitialization of `eventsFlow`
             Relay = RelayClient(dappKoinApp)
 
             // Override of storage instances and depending objects
-            dappKoinApp.modules(overrideModule(Relay, Pairing, PairingController, "test_dapp", RELAY_URL, ConnectionType.MANUAL, app.packageName))
+            dappKoinApp.modules(
+                overrideModule(
+                    Relay,
+                    Pairing,
+                    PairingController,
+                    "test_dapp",
+                    "wss://relay.walletconnect.org?projectId=${BuildConfig.PROJECT_ID}",
+                    ConnectionType.MANUAL,
+                    app.packageName
+                )
+            )
 
             // Necessary reinit of Relay, Pairing and PairingController
             Relay.initialize { Timber.e(it) }
@@ -105,13 +114,23 @@ internal object TestClient {
 
         private val coreProtocol = CoreProtocol(hybridKoinApp).apply {
             Timber.d("Hybrid CP start: ")
-            initialize(metadata, RELAY_URL, ConnectionType.MANUAL, app) { Timber.e(it.throwable) }
+            initialize(app, BuildConfig.PROJECT_ID, metadata, ConnectionType.MANUAL) { Timber.e(it.throwable) }
 
             // Override of previous Relay necessary for reinitialization of `eventsFlow`
             Relay = RelayClient(hybridKoinApp)
 
             // Override of storage instances and depending objects
-            hybridKoinApp.modules(overrideModule(Relay, Pairing, PairingController, "test_hybrid", RELAY_URL, ConnectionType.MANUAL, app.packageName))
+            hybridKoinApp.modules(
+                overrideModule(
+                    Relay,
+                    Pairing,
+                    PairingController,
+                    "test_hybrid",
+                    "wss://relay.walletconnect.org?projectId=${BuildConfig.PROJECT_ID}",
+                    ConnectionType.MANUAL,
+                    app.packageName
+                )
+            )
 
             // Necessary reinit of Relay, Pairing and PairingController
             Relay.initialize { Timber.e(it) }

--- a/sample/common/src/main/kotlin/com/walletconnect/sample/common/Constants.kt
+++ b/sample/common/src/main/kotlin/com/walletconnect/sample/common/Constants.kt
@@ -1,3 +1,3 @@
 package com.walletconnect.sample.common
 
-const val RELAY_URL = "relay.walletconnect.com"
+const val RELAY_URL = "relay.walletconnect.org"

--- a/sample/dapp/src/main/kotlin/com/walletconnect/sample/dapp/DappSampleApp.kt
+++ b/sample/dapp/src/main/kotlin/com/walletconnect/sample/dapp/DappSampleApp.kt
@@ -6,9 +6,7 @@ import com.google.firebase.crashlytics.ktx.crashlytics
 import com.google.firebase.ktx.Firebase
 import com.walletconnect.android.Core
 import com.walletconnect.android.CoreClient
-import com.walletconnect.android.relay.ConnectionType
 import com.walletconnect.sample.common.BuildConfig
-import com.walletconnect.sample.common.RELAY_URL
 import com.walletconnect.sample.common.tag
 import com.walletconnect.wcmodal.client.Modal
 import com.walletconnect.wcmodal.client.WalletConnectModal
@@ -19,7 +17,6 @@ class DappSampleApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        val serverUri = "wss://$RELAY_URL?projectId=${BuildConfig.PROJECT_ID}"
         val appMetaData = Core.Model.AppMetaData(
             name = "Kotlin Dapp",
             description = "Kotlin Dapp Implementation",
@@ -29,9 +26,8 @@ class DappSampleApp : Application() {
         )
 
         CoreClient.initialize(
-            relayServerUrl = serverUri,
-            connectionType = ConnectionType.AUTOMATIC,
             application = this,
+            projectId = BuildConfig.PROJECT_ID,
             metaData = appMetaData,
         ) {
             Firebase.crashlytics.recordException(it.throwable)

--- a/sample/modal/src/main/kotlin/com/walletconnect/sample/modal/ModalSampleApp.kt
+++ b/sample/modal/src/main/kotlin/com/walletconnect/sample/modal/ModalSampleApp.kt
@@ -8,7 +8,6 @@ import com.walletconnect.android.Core
 import com.walletconnect.android.CoreClient
 import com.walletconnect.android.relay.ConnectionType
 import com.walletconnect.sample.common.BuildConfig
-import com.walletconnect.sample.common.RELAY_URL
 import com.walletconnect.sample.common.tag
 import com.walletconnect.web3.modal.client.Modal
 import com.walletconnect.web3.modal.client.Web3Modal
@@ -19,7 +18,6 @@ class ModalSampleApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        val serverUri = "wss://$RELAY_URL?projectId=${BuildConfig.PROJECT_ID}"
         val appMetaData = Core.Model.AppMetaData(
             name = "Kotlin Modals",
             description = "Kotlin Modals Lab Sample",
@@ -29,7 +27,7 @@ class ModalSampleApp : Application() {
         )
 
         CoreClient.initialize(
-            relayServerUrl = serverUri,
+            projectId = BuildConfig.PROJECT_ID,
             connectionType = ConnectionType.AUTOMATIC,
             application = this,
             metaData = appMetaData,

--- a/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/Web3WalletApplication.kt
+++ b/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/Web3WalletApplication.kt
@@ -20,13 +20,11 @@ import com.walletconnect.android.CoreClient
 import com.walletconnect.android.cacao.signature.SignatureType
 import com.walletconnect.android.internal.common.di.AndroidCommonDITags
 import com.walletconnect.android.internal.common.wcKoinApp
-import com.walletconnect.android.relay.ConnectionType
 import com.walletconnect.android.utils.cacao.sign
 import com.walletconnect.foundation.util.Logger
 import com.walletconnect.notify.client.Notify
 import com.walletconnect.notify.client.NotifyClient
 import com.walletconnect.notify.client.cacao.CacaoSigner
-import com.walletconnect.sample.common.RELAY_URL
 import com.walletconnect.sample.common.initBeagle
 import com.walletconnect.sample.common.tag
 import com.walletconnect.sample.wallet.domain.EthAccountDelegate
@@ -60,7 +58,6 @@ class Web3WalletApplication : Application() {
         EthAccountDelegate.application = this
 
         val projectId = BuildConfig.PROJECT_ID
-        val serverUrl = "wss://$RELAY_URL?projectId=$projectId"
         val appMetaData = Core.Model.AppMetaData(
             name = "Kotlin Wallet",
             description = "Kotlin Wallet Implementation",
@@ -70,9 +67,8 @@ class Web3WalletApplication : Application() {
         )
 
         CoreClient.initialize(
-            relayServerUrl = serverUrl,
-            connectionType = ConnectionType.AUTOMATIC,
             application = this,
+            projectId = projectId,
             metaData = appMetaData,
             onError = { error ->
                 Firebase.crashlytics.recordException(error.throwable)

--- a/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/Web3WalletApplication.kt
+++ b/sample/wallet/src/main/kotlin/com/walletconnect/sample/wallet/Web3WalletApplication.kt
@@ -72,7 +72,7 @@ class Web3WalletApplication : Application() {
             metaData = appMetaData,
             onError = { error ->
                 Firebase.crashlytics.recordException(error.throwable)
-                logger.error(error.throwable.stackTraceToString())
+                println(error.throwable.stackTraceToString())
                 scope.launch {
                     connectionStateFlow.emit(ConnectionState.Error(error.throwable.message ?: ""))
                 }


### PR DESCRIPTION
This PR removes the .org fallback for the Relay. From now on, the default connection URL is .org with 5s timeout.