### PR TITLE
Move defining column list adapters

### DIFF
--- a/core/android/src/main/kotlin/com/walletconnect/android/internal/common/di/AndroidCommonDITags.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/internal/common/di/AndroidCommonDITags.kt
@@ -3,7 +3,6 @@ package com.walletconnect.android.internal.common.di
 enum class AndroidCommonDITags {
     MOSHI,
     SHARED_INTERCEPTOR,
-    FAIL_OVER_INTERCEPTOR,
     LOGGING_INTERCEPTOR,
     AUTHENTICATOR,
     OK_HTTP,

--- a/core/android/src/main/kotlin/com/walletconnect/android/internal/common/di/BaseStorageModule.kt
+++ b/core/android/src/main/kotlin/com/walletconnect/android/internal/common/di/BaseStorageModule.kt
@@ -29,24 +29,6 @@ import org.koin.dsl.module
 import com.walletconnect.android.internal.common.scope as wcScope
 
 fun baseStorageModule(storagePrefix: String = String.Empty, bundleId: String) = module {
-
-    fun Scope.createCoreDB(): AndroidCoreDatabase = AndroidCoreDatabase(
-        driver = get(named(AndroidBuildVariantDITags.ANDROID_CORE_DATABASE_DRIVER)),
-        MetaDataAdapter = MetaData.Adapter(
-            iconsAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_LIST)),
-            typeAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_APPMETADATATYPE))
-        ),
-        VerifyContextAdapter = VerifyContext.Adapter(
-            validationAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_VALIDATION))
-        ),
-        EventDaoAdapter = EventDao.Adapter(
-            traceAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_LIST))
-        ),
-        JsonRpcHistoryDaoAdapter = JsonRpcHistoryDao.Adapter(
-            transport_typeAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_TRANSPORT_TYPE))
-        )
-    )
-
     single<ColumnAdapter<List<String>, String>>(named(AndroidCommonDITags.COLUMN_ADAPTER_LIST)) {
         object : ColumnAdapter<List<String>, String> {
             override fun decode(databaseValue: String): List<String> =
@@ -81,6 +63,23 @@ fun baseStorageModule(storagePrefix: String = String.Empty, bundleId: String) = 
     single<ColumnAdapter<TransportType, String>>(named(AndroidCommonDITags.COLUMN_ADAPTER_TRANSPORT_TYPE)) { EnumColumnAdapter() }
 
     single<ColumnAdapter<Validation, String>>(named(AndroidCommonDITags.COLUMN_ADAPTER_VALIDATION)) { EnumColumnAdapter() }
+
+    fun Scope.createCoreDB(): AndroidCoreDatabase = AndroidCoreDatabase(
+        driver = get(named(AndroidBuildVariantDITags.ANDROID_CORE_DATABASE_DRIVER)),
+        MetaDataAdapter = MetaData.Adapter(
+            iconsAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_LIST)),
+            typeAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_APPMETADATATYPE))
+        ),
+        VerifyContextAdapter = VerifyContext.Adapter(
+            validationAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_VALIDATION))
+        ),
+        EventDaoAdapter = EventDao.Adapter(
+            traceAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_LIST))
+        ),
+        JsonRpcHistoryDaoAdapter = JsonRpcHistoryDao.Adapter(
+            transport_typeAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_TRANSPORT_TYPE))
+        )
+    )
 
     single<AndroidCoreDatabase>(named(AndroidBuildVariantDITags.ANDROID_CORE_DATABASE)) {
         try {

--- a/protocol/sign/src/main/kotlin/com/walletconnect/sign/di/StorageModule.kt
+++ b/protocol/sign/src/main/kotlin/com/walletconnect/sign/di/StorageModule.kt
@@ -25,6 +25,8 @@ import com.walletconnect.android.internal.common.scope as wcScope
 
 @JvmSynthetic
 internal fun storageModule(dbName: String): Module = module {
+    includes(sdkBaseStorageModule(SignDatabase.Schema, dbName))
+
     fun Scope.createSignDB(): SignDatabase = SignDatabase(
         driver = get(named(dbName)),
         NamespaceDaoAdapter = NamespaceDao.Adapter(
@@ -58,8 +60,6 @@ internal fun storageModule(dbName: String): Module = module {
             iconsAdapter = get(named(AndroidCommonDITags.COLUMN_ADAPTER_LIST))
         )
     )
-
-    includes(sdkBaseStorageModule(SignDatabase.Schema, dbName))
 
     single {
         try {


### PR DESCRIPTION
Move defining column list adapters to the top of the koin module to assure that they're available immediately when CoreClient is initialized