### PR TITLE
Fix Web3ModalSheet dismiss on state loss

### DIFF
--- a/product/web3modal/src/main/kotlin/com/walletconnect/web3/modal/ui/Web3ModalSheet.kt
+++ b/product/web3modal/src/main/kotlin/com/walletconnect/web3/modal/ui/Web3ModalSheet.kt
@@ -76,7 +76,18 @@ class Web3ModalSheet : BottomSheetDialogFragment() {
                 modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
                 navController = navController,
                 shouldOpenChooseNetwork = shouldOpenChooseNetwork,
-                closeModal = { this@Web3ModalSheet.dismiss() })
+                closeModal = {
+                    if (isAdded) {
+                        if (!isStateSaved) {
+                            this@Web3ModalSheet.dismiss()
+                        } else {
+                            Handler(Looper.getMainLooper()).post {
+                                this@Web3ModalSheet.dismissAllowingStateLoss()
+                            }
+                        }
+                    }
+                }
+            )
         }
     }
 


### PR DESCRIPTION
Error Example & Question : [Discord](https://discord.com/channels/492410046307631105/1268399498003091517)
``` 
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
                        	at androidx.fragment.app.FragmentManager.checkStateLoss(FragmentManager.java:1632)
                        	at androidx.fragment.app.FragmentManager.enqueueAction(FragmentManager.java:1672)
                        	at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:341)
                        	at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:306)
                        	at androidx.fragment.app.DialogFragment.dismissInternal(DialogFragment.java:621)
                        	at androidx.fragment.app.DialogFragment.dismiss(DialogFragment.java:555)
                        	at com.google.android.material.bottomsheet.BottomSheetDialogFragment.dismiss(BottomSheetDialogFragment.java:61)
                        	at com.walletconnect.web3.modal.ui.Web3ModalSheet$Web3ModalComposeView$1$1$1.invoke(Web3ModalSheet.kt:79)
                        	at com.walletconnect.web3.modal.ui.Web3ModalSheet$Web3ModalComposeView$1$1$1.invoke(Web3ModalSheet.kt:79)
                        	at com.walletconnect.web3.modal.ui.components.internal.Web3ModalComponentKt$Web3ModalComponent$2$1.invokeSuspend(Web3ModalComponent.kt:65)
                        	at com.walletconnect.web3.modal.ui.components.internal.Web3ModalComponentKt$Web3ModalComponent$2$1.invoke(Unknown Source:8)
                        	at com.walletconnect.web3.modal.ui.components.internal.Web3ModalComponentKt$Web3ModalComponent$2$1.invoke(Unknown Source:4)
```